### PR TITLE
Log bulk.execute() errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,12 @@ class MongoBulkWriteStream extends Writable {
   _flush (next) {
     if (!this._isEmpty) {
       try {
-        return this._bulk.execute(this._bulkExecuteOptions, () => next());
+        return this._bulk.execute(this._bulkExecuteOptions, (err) => {
+          if (err) {
+            console.log(err);
+          }
+          next();
+        });
       } catch (err) {
         next(err instanceof Error ? err : new Error(err));
       }


### PR DESCRIPTION
Log bulk.execute() errors to console.
1. Don't emit error (as this may break pre-existing scripts relying on this lib)
2. Add a console.log so we have visibility of the error when writing to the DB